### PR TITLE
workaround crash for empty channels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 
 # editor
 .vscode
+.idea

--- a/src/series.py
+++ b/src/series.py
@@ -164,8 +164,8 @@ class Show:
     def _get_ta_channel(self) -> TAChannel | None:
         """get ta channel metadata"""
         episodes: list[JFEpisode] = self._get_all_episodes(limit=1)
-        if(len(episodes) == 0):
-            return None
+        if not episodes:
+            return
         episode: JFEpisode = episodes[0]
         youtube_id: str = os.path.split(episode["Path"])[-1][9:20]
         path = f"/video/{youtube_id}"

--- a/src/series.py
+++ b/src/series.py
@@ -155,13 +155,18 @@ class Show:
 
     def validate_show(self) -> None:
         """set show metadata"""
-        ta_channel: TAChannel = self._get_ta_channel()
+        ta_channel: TAChannel | None = self._get_ta_channel()
+        if ta_channel is None:
+            return
         self.update_metadata(ta_channel)
         self.update_artwork(ta_channel)
 
-    def _get_ta_channel(self) -> TAChannel:
+    def _get_ta_channel(self) -> TAChannel | None:
         """get ta channel metadata"""
-        episode: JFEpisode = self._get_all_episodes(limit=1)[0]
+        episodes: list[JFEpisode] = self._get_all_episodes(limit=1)
+        if(len(episodes) == 0):
+            return None
+        episode: JFEpisode = episodes[0]
         youtube_id: str = os.path.split(episode["Path"])[-1][9:20]
         path = f"/video/{youtube_id}"
 


### PR DESCRIPTION
Resolves #5

PS: I don't know if that's the best way to handle this by just ignoring the channel if no Video (JF Episode) is found for it, but I also don't have a better idea on how to handle it. So please feel free to comment or suggest other ideas.