### PR TITLE
Fix first run errors

### DIFF
--- a/app/src/series.py
+++ b/app/src/series.py
@@ -192,7 +192,10 @@ class Show:
             os.path.split(jf_ep["Path"].replace("\\", "/"))[0]
         )[-1]
         season_folder = os.path.join(base, channel_folder, expected_season)
-        os.makedirs(season_folder)
+        try:
+            os.makedirs(season_folder)
+        except FileExistsError:
+            pass
         self._wait_for_season(expected_season)
 
         return season_folder
@@ -219,7 +222,7 @@ class Show:
         path: str = f"Shows/{series_id}/Seasons"
         all_seasons: dict = Jellyfin().get(path)
 
-        return [str(i.get("IndexNumber")) for i in all_seasons["Items"]]
+        return [str(i.get("Name")) for i in all_seasons["Items"]]
 
     def delete_folders(self, folders: list[str]) -> None:
         """delete temporary folders created"""


### PR DESCRIPTION
This fixes 2 errors I've noticed when running for the first time.

1. If the folder for the seasons already exists (from a previous run for example), the script dies.
2. The field `IndexNumber` doesn't exists for Seasons created by the script. Also it's looking for seasons named `"2022"` (so a `str`) for example while the IndexNumber is an `int`.

This seems related to #10 . 