### PR TITLE
Update README.md to remove interactive flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Mount the `/youtube` folder from Tube Archivist also in this container at `/yout
 ### Manual trigger
 For an initial import or for other irregular occasions, trigger the library scan from outside the container, e.g.:
 ```bash
-docker exec -it tubearchivist-jf python main.py
+docker exec tubearchivist-jf python main.py
 ```
 
 ### Auto trigger


### PR DESCRIPTION
Remove the -it flag from the docker exec command. It's not needed given the command is not interactive, and it means this command wont work with cron.